### PR TITLE
Fix README lab links and add missing courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,102 +9,119 @@
 Labs organized by course and lab number.
 
 ### CMGT:559-Managing-Risk-and-Security-vs-Opportunity
-- **Lab 1:** Quarantine vulnerable system
-- **Lab 2:** OSSIM
+- [Lab 1: Quarantine vulnerable system](<./CMGT:559-Managing-Risk-and-Security-vs-Opportunity/Lab1-Quarantine-vulnerable-system>)
+- [Lab 2: OSSIM](<./CMGT:559-Managing-Risk-and-Security-vs-Opportunity/Lab2-OSSIM>)
 
 ### CYB:500-Advanced-Cybersecurity-Concepts
-- **Lab 1:** Setting up Honeypot
-- **Lab 2:** Iptables Personal Firewall
-- **Lab 3:** Hping Program
-- **Lab 4:** Nmap Local Network Scan
-- **Lab 5:** Network Reconnaissance
-- **Lab 6:** Metasploit Search Options
-- **Lab 7:** Making Syslog Entries Readable
-- **Lab 8:** Nslookup Passive Reconnaissance
-- **Lab 9:** Inspect vulnerability echo server source code
-- **Lab 10:** Session Hijacking BurpSuite
-- **Lab 11:** Conduct Vulnerability Scanning Nessus
-- **Lab 12:** Using OWASP ZAP
-- **Lab 13:** Perform Vulnerability Scan OpenVAS
-- **Lab 14:** Perform MITM attack
-- **Lab 15:** Performing Memorybased attack
-- **Lab 16:** Using MD5 Hash
-- **Lab 17:** Apktool Decode APK
-- **Lab 18:** Logging audited objects
-- **Lab 19:** Examine audited events
-- **Lab 20:** Configure Snort
-- **Lab 21:** Confirm spoofing wireshark
-- **Lab 22:** Attack website XSS
-- **Lab 23:** Encrypt Decrypt Kleopatra
-- **Lab 24:** AES crypt
-- **Lab 25:** Detect rootkit
-- **Lab 26:** Exploit website SQL
+- [Lab 1: Setting up Honeypot](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab1-Setting-up-Honeypot>)
+- [Lab 2: Iptables Personal Firewall](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab2-iptables-Personal-Firewall>)
+- [Lab 3: Hping Program](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab3-hping-Program>)
+- [Lab 4: Nmap Local Network Scan](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab4-nmap-Local-Network-Scan>)
+- [Lab 5: Network Reconnaissance](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab5-Network-Reconnaissance>)
+- [Lab 6: Metasploit Search Options](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab6-Metasploit-Search-Options>)
+- [Lab 7: Making Syslog Entries Readable](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab7-Making-Syslog-Entries-Readable>)
+- [Lab 8: Nslookup Passive Reconnaissance](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab8-Nslookup-Passive-Reconnaissance>)
+- [Lab 9: Inspect vulnerability echo server source code](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab9-inspect-vulnerability-echo-server-source-code>)
+- [Lab 10: Session Hijacking BurpSuite](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab10-Session-Hijacking-BurpSuite>)
+- [Lab 11: Conduct Vulnerability Scanning Nessus](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab11-Conduct-Vulnerability-Scanning-Nessus>)
+- [Lab 12: Using OWASP ZAP](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab12-Using-OWASP-ZAP>)
+- [Lab 13: Perform Vulnerability Scan OpenVAS](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab13-Perform-Vulnerability-Scan-OpenVAS>)
+- [Lab 14: Perform MITM attack](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab14-Perform-MITM-attack>)
+- [Lab 15: Performing Memorybased attack](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab15-Performing-Memorybased-attack>)
+- [Lab 16: Using MD5 Hash](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab16-Using-MD5-Hash>)
+- [Lab 17: Apktool Decode APK](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab17-Apktool-Decode-APK>)
+- [Lab 18: Logging audited objects](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab18-logging-audited-objects>)
+- [Lab 19: Examine audited events](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab19-examine-audited-events>)
+- [Lab 20: Configure Snort](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab20-configure-Snort>)
+- [Lab 21: Confirm spoofing wireshark](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab21-confirm-spoofing-wireshark>)
+- [Lab 22: Attack website XSS](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab22-attack-website-XSS>)
+- [Lab 23: Encrypt Decrypt Kleopatra](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab23-Encrypt-Decrypt-Kelopatra>)
+- [Lab 24: AES crypt](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab24-AES-crypt>)
+- [Lab 25: Detect rootkit](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab25-detect-rootkit>)
+- [Lab 26: Exploit website SQL](<./CYB:500-Advanced-Cybersecurity-Concepts/Lab26-exploit-website-SQL>)
+
+### CYB:505-Secure-Software-Development
+- [Course README](<./CYB:505-Secure-Software-Development/README.md>)
 
 ### CYB:510-Cloud-Security
-- **Lab 1:** Create DMZ
-- **Lab 2:** IPsec VPN
-- **Lab 3:** Create VM Install Ubuntu HyperV
-- **Lab 4:** Configure RAID5
-- **Lab 5:** SHA generated value
-- **Lab 6:** DoS attack SYN floo
-- **Lab 7:** SEtoolkit social engineering
-- **Lab 8:** Perform credential brute force
+- [Lab 1: Create DMZ](<./CYB:510-Cloud-Security/Lab1-Create-DMZ>)
+- [Lab 2: IPsec VPN](<./CYB:510-Cloud-Security/Lab2-IPsec-VPN>)
+- [Lab 3: Create VM Install Ubuntu HyperV](<./CYB:510-Cloud-Security/Lab3-Create-VM-Install-Ubuntu-HyperV>)
+- [Lab 4: Configure RAID5](<./CYB:510-Cloud-Security/Lab4-Configure-RAID5>)
+- [Lab 5: SHA generated value](<./CYB:510-Cloud-Security/Lab5-SHA-generated-value>)
+- [Lab 6: DoS attack SYN floo](<./CYB:510-Cloud-Security/Lab6-DoS-attack-SYN-floo>)
+- [Lab 7: SEtoolkit social engineering](<./CYB:510-Cloud-Security/Lab7-SEtoolkit-social-engineering>)
+- [Lab 8: Perform credential brute force](<./CYB:510-Cloud-Security/Lab8-Perform-credential-brute-force>)
 
 ### CYB:515-Network-Security
-- **Lab 1:** Using Etherdetect
-- **Lab 2:** Crack pass Ophcrack
-- **Lab 3:** Share Enum
-- **Lab 4:** Use MBSA
-- **Lab 5:** Advanced IP scanner
-- **Lab 6:** Remote Access Trojan
-- **Lab 7:** Create Security Policy
-- **Lab 8:** Elitewrap
-- **Lab 9:** John the Ripper
-- **Lab 10:** Rainbow tables
+- [Lab 1: Using Etherdetect](<./CYB:515-Network-Security/Lab1-using-Etherdetect>)
+- [Lab 2: Crack pass Ophcrack](<./CYB:515-Network-Security/Lab2-crack-pass-Ophcrack>)
+- [Lab 3: Share Enum](<./CYB:515-Network-Security/Lab3-Share-Enum>)
+- [Lab 4: Use MBSA](<./CYB:515-Network-Security/Lab4-Use-MBSA>)
+- [Lab 5: Advanced IP scanner](<./CYB:515-Network-Security/Lab5-Advanced-IP-scanner>)
+- [Lab 6: Remote Access Trojan](<./CYB:515-Network-Security/Lab6-Remote-Access-Trojan>)
+- [Lab 7: Create Security Policy](<./CYB:515-Network-Security/Lab7-Create-Security-Policy>)
+- [Lab 8: Elitewrap](<./CYB:515-Network-Security/Lab8-elitewrap>)
+- [Lab 9: John the Ripper](<./CYB:515-Network-Security/Lab9-John-the-Ripper>)
+- [Lab 10: Rainbow tables](<./CYB:515-Network-Security/Lab10-rainbow-tables>)
+
+### CYB:520-Cyber-Ethics
+- [Cyber Ethics in Everyday Life](<./CYB:520-Cyber-Ethics/Cyber-Ethics>)
 
 ### CYB:530-Cybersecurity-Practitioner
-- **Lab 1:** Starting packet capture
-- **Lab 2:** Spoof MAC
-- **Lab 3:** Examine traffic client server
-- **Lab 4:** IIS Server role
-- **Lab 5:** Remediate Vulnerabilites Workstation
-- **Lab 6:** Remediate Vulnerabilites network
-- **Lab 7:** Prevent DNS Zone Transfers
+- [Lab 1: Starting packet capture](<./CYB:530-Cybersecurity-Practitioner/Lab1-Starting-packet-capture>)
+- [Lab 2: Spoof MAC](<./CYB:530-Cybersecurity-Practitioner/Lab2-spoof-MAC>)
+- [Lab 3: Examine traffic client server](<./CYB:530-Cybersecurity-Practitioner/Lab3-examine-traffic-client-server>)
+- [Lab 4: IIS Server role](<./CYB:530-Cybersecurity-Practitioner/Lab4-IIS-Server-role>)
+- [Lab 5: Remediate Vulnerabilites Workstation](<./CYB:530-Cybersecurity-Practitioner/Lab5-Remediate-Vulnerabilites-Workstation>)
+- [Lab 6: Remediate Vulnerabilites network](<./CYB:530-Cybersecurity-Practitioner/Lab6-Remediate-Vulnerabilites-network>)
+- [Lab 7: Prevent DNS Zone Transfers](<./CYB:530-Cybersecurity-Practitioner/Lab7-Prevent-DNS-Zone-Transfers>)
 
 ### CYB:535-Secure-Programming
-- **Lab 1:** Monitor Log Deployed App
-- **Lab 2:** Testsuite automate testing
-- **Lab 3:** Authentication Authorization defects
-- **Lab 4:** Protect Data rest transit
-- **Lab 5:** Staging persistant XSS admin
+- [Lab 1: Monitor Log Deployed App](<./CYB:535-Secure-Programming/Lab1-Monitor-Log-Deployed-App>)
+- [Lab 2: Testsuite automate testing](<./CYB:535-Secure-Programming/Lab2-Testsuite-automate-testing>)
+- [Lab 3: Authentication Authorization defects](<./CYB:535-Secure-Programming/Lab3-Authentication-Authorization-defects>)
+- [Lab 4: Protect Data rest transit](<./CYB:535-Secure-Programming/Lab4-Protect-Data-rest-transit>)
+- [Lab 5: Staging persistant XSS admin](<./CYB:535-Secure-Programming/Lab5-staging-ersistant-XSS-admin>)
 
 ### CYB:540: Cryptography
-- **Lab 1:** Using Steganography
-- **Lab 2:** Keylogger target machine
-- **Lab 3:** Failover Cluster
-- **Lab 4:** OpenSSL private public key
-- **Lab 5:** RSA Asymmetric Algorithm
+- [Lab 1: Using Steganography](<./CYB:540: Cryptography/Lab1-Using-Steganography>)
+- [Lab 2: Keylogger target machine](<./CYB:540: Cryptography/Lab2-Keylogger-target-machine>)
+- [Lab 3: Failover Cluster](<./CYB:540: Cryptography/Lab3-Failover-Cluster>)
+- [Lab 4: OpenSSL private public key](<./CYB:540: Cryptography/Lab4-OpenSSL-private-public-key>)
+- [Lab 5: RSA Asymmetric Algorithm](<./CYB:540: Cryptography/Lab5-RSA-Asymmetric-Algorithm>)
+
+### CYB:545-Threat-Intelligence
+- [Week 1: Threat Intelligence Report](<./CYB:545-Threat-Intelligence/Week1-Threat-Intelligence-Report>)
+- [Week 2: Maintain Data Reports](<./CYB:545-Threat-Intelligence/Week-2-Maintain-Data-Reports>)
+- [Week 4: Threat Analysis Collection](<./CYB:545-Threat-Intelligence/Week4-Threat-Analysis-Collection>)
+- [Week 6: Threat Intelligence Summary](<./CYB:545-Threat-Intelligence/Week6-Threat-Intelligence-Summary>)
 
 ### CYB:550: Technical Enterprise Security
-- **Lab 1:** ExifTool metadata Extraction
-- **Lab 2:** CSRF Attack
-- **Lab 3:** Perform ARP Poisioning
-- **Lab 4:** Bypass commandshell restrictions
-- **Lab 5:** Netcat Reverse Shell
+- [Lab 1: ExifTool metadata Extraction](<./CYB:550: Technical Enterprise Security/Lab1-ExifTool-metadata-Extraction>)
+- [Lab 2: CSRF Attack](<./CYB:550: Technical Enterprise Security/Lab2-CSRF-Attack>)
+- [Lab 3: Perform ARP Poisioning](<./CYB:550: Technical Enterprise Security/Lab3-Perform-ARP-Poisioning>)
+- [Lab 4: Bypass commandshell restrictions](<./CYB:550: Technical Enterprise Security/Lab4-Bypass-commandshell-restrictions>)
+- [Lab 5: Netcat Reverse Shell](<./CYB:550: Technical Enterprise Security/Lab5-Netcat-Reverse-Shell>)
+- [Week 3: Pentester characteristics](<./CYB:550: Technical Enterprise Security/Week3-Pentester-characteristics>)
+- [Week 6: OSINT Research](<./CYB:550: Technical Enterprise Security/Week6-OSINT-Research>)
 
 ### CYB:555-Enterprise-Security-Operations
-- **Lab 1:** Attempt Zone Transfer
-- **Lab 2:** AD DS
+- [Lab 1: Attempt Zone Transfer](<./CYB:555-Enterprise-Security-Operations/Lab1-Attempt-Zone-Transfer>)
+- [Lab 2: AD DS](<./CYB:555-Enterprise-Security-Operations/Lab2-AD-DS>)
+- [Week 4: Security Plan Mobile Devices](<./CYB:555-Enterprise-Security-Operations/Week4-Security-Plan-Mobile-Devices>)
 
 ### CYB:560-Mscyb-Capstone
-- **Lab 1:** Maltego Footprint
-- **Lab 2:** Osquery advanced
-- **Lab 3:** Autopsy forensics
-- **Lab 4:** TOCTOU exploit
-- **Lab 5:** SSH Config
-- **Lab 6:** Reset root password
-- **Lab 7:** DHCP Starvation
-- **Lab 8:** Vega web analysis
+- [Lab 1: Maltego Footprint](<./CYB:560-Mscyb-Capstone/Lab1-Maltego-Footprint>)
+- [Lab 2: Osquery advanced](<./CYB:560-Mscyb-Capstone/Lab2-Osquery-advanced>)
+- [Lab 3: Autopsy forensics](<./CYB:560-Mscyb-Capstone/Lab3-autopsy-forensics>)
+- [Lab 4: TOCTOU exploit](<./CYB:560-Mscyb-Capstone/Lab4-TOCTOU-exploit>)
+- [Lab 5: SSH Config](<./CYB:560-Mscyb-Capstone/Lab5-SSH-Config>)
+- [Lab 6: Reset root password](<./CYB:560-Mscyb-Capstone/Lab6-reset-root-password>)
+- [Lab 7: DHCP Starvation](<./CYB:560-Mscyb-Capstone/Lab7-DHCP-Starvation>)
+- [Lab 8: Vega web analysis](<./CYB:560-Mscyb-Capstone/Lab8-vega-web-analysis>)
+- [Week 1: Risk Managment](<./CYB:560-Mscyb-Capstone/Week1-Risk-Managment>)
+- [Week 3: Mitigation project](<./CYB:560-Mscyb-Capstone/Week3-Mitigation-project>)
 
 ---
 ## About This Repository


### PR DESCRIPTION
## Summary
- Link course 505 in Lab Index
- Correct Cryptography and Technical Enterprise Security paths with spaces
- Add missing week assignments for courses 550, 555, and 560

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bbe6ad5908322a21e2f6b64b8cfa8